### PR TITLE
feat : profile 테이블에 유저의 이메일 정보를 저장하도록 수정

### DIFF
--- a/ottogether/src/pages/Register/Register.tsx
+++ b/ottogether/src/pages/Register/Register.tsx
@@ -144,7 +144,6 @@ function Register() {
       if(confirmDelete) {
         setUserName('');
         setUserPhoneNumber('');
-        navigate('/register/detail');
       } else {
         agreeFieldRef.current?.scrollIntoView();
         agreeFieldRef.current?.focus();
@@ -153,11 +152,13 @@ function Register() {
     }
 
     // supabase auth 통신
-    const result:RegisterReturns = await authRegister(userEmail, userPassword, userPhoneNumber, { name: userName });
+    const result:RegisterReturns = await authRegister(userEmail, userPassword, 
+      agreement ? { phone: userPhoneNumber.trim(), name: userName.trim() } : undefined);
     if (result.success) {
       navigate('/register/detail', { 
         state: {
-          userId: result.userId
+          userId: result.userId,
+          userEmail: userEmail,
         }
       });
     } else {

--- a/ottogether/src/supabase/auth/authRegister.ts
+++ b/ottogether/src/supabase/auth/authRegister.ts
@@ -10,18 +10,21 @@ export type RegisterReturns =
 export const authRegister = async (
   email: string,
   password: string,
-  phone: string,
-  options: { name:string }
+  options?: { 
+    name?:string 
+    phone?: string,
+  }
 ): Promise<RegisterReturns> => {
+
+  const userMetadata: Record<string, string> = {};
+  if(options?.name) userMetadata.name = options.name;
 
   const { data, error } = await supabase.auth.signUp({
     email,
     password,
-    phone,
+    phone: options?.phone,
     options: {
-      data: {
-        name: options.name
-      }
+      data: userMetadata
     }
   });
 

--- a/ottogether/src/supabase/supabase.type.ts
+++ b/ottogether/src/supabase/supabase.type.ts
@@ -21,7 +21,7 @@ export type Database = {
           review_id: number
           text_content: string
           updated_at: string
-          user_id: number
+          user_id: string
         }
         Insert: {
           created_at?: string
@@ -29,7 +29,7 @@ export type Database = {
           review_id?: number
           text_content?: string
           updated_at?: string
-          user_id?: number
+          user_id: string
         }
         Update: {
           created_at?: string
@@ -37,7 +37,7 @@ export type Database = {
           review_id?: number
           text_content?: string
           updated_at?: string
-          user_id?: number
+          user_id?: string
         }
         Relationships: []
       }
@@ -46,6 +46,7 @@ export type Database = {
           avatar_url: string | null
           bio: string | null
           created_at: string
+          email_address: string
           favorite_genre: string[] | null
           header_url: string | null
           nickname: string | null
@@ -58,6 +59,7 @@ export type Database = {
           avatar_url?: string | null
           bio?: string | null
           created_at?: string
+          email_address: string
           favorite_genre?: string[] | null
           header_url?: string | null
           nickname?: string | null
@@ -70,6 +72,7 @@ export type Database = {
           avatar_url?: string | null
           bio?: string | null
           created_at?: string
+          email_address?: string
           favorite_genre?: string[] | null
           header_url?: string | null
           nickname?: string | null
@@ -122,18 +125,21 @@ export type Database = {
       quotes_like: {
         Row: {
           created_at: string
-          review_id: number
-          user_id: number
+          id: number | null
+          quote_id: number | null
+          user_id: string | null
         }
         Insert: {
           created_at: string
-          review_id?: number
-          user_id?: number
+          id?: number | null
+          quote_id?: number | null
+          user_id?: string | null
         }
         Update: {
           created_at?: string
-          review_id?: number
-          user_id?: number
+          id?: number | null
+          quote_id?: number | null
+          user_id?: string | null
         }
         Relationships: []
       }
@@ -148,7 +154,7 @@ export type Database = {
           rating: number
           text_content: string
           updated_at: string
-          user_id: number
+          user_id: string | null
         }
         Insert: {
           comment_count?: number
@@ -160,7 +166,7 @@ export type Database = {
           rating: number
           text_content?: string
           updated_at?: string
-          user_id?: number
+          user_id?: string | null
         }
         Update: {
           comment_count?: number
@@ -172,7 +178,7 @@ export type Database = {
           rating?: number
           text_content?: string
           updated_at?: string
-          user_id?: number
+          user_id?: string | null
         }
         Relationships: []
       }
@@ -181,19 +187,19 @@ export type Database = {
           created_at: string
           reaction_type: Database["public"]["Enums"]["Like/Dislike"] | null
           review_id: number
-          user_id: number
+          user_id: string | null
         }
         Insert: {
           created_at?: string
           reaction_type?: Database["public"]["Enums"]["Like/Dislike"] | null
           review_id?: number
-          user_id?: number
+          user_id?: string | null
         }
         Update: {
           created_at?: string
           reaction_type?: Database["public"]["Enums"]["Like/Dislike"] | null
           review_id?: number
-          user_id?: number
+          user_id?: string | null
         }
         Relationships: []
       }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
Profile 테이블에 유저의 이메일 정보도 저장하도록 Register, RegisterDetail 페이지 수정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 비밀번호 변경 작업을 위해서 Profile 테이블에도 Auth.Users 테이블과 동일한 유저의 이메일을 저장해야 함
- user_id와 함께 email_address도 location.state & supabase session 에서 값을 받아와서 profile 테이블에 upsert 하도록 변경함

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
@cheezstick 유하님, profile 테이블에 email_address 라는 컬럼명으로 만들었으니 참고해주세요!