### PR TITLE
bug : RegisterProfile 에서 값을 입력할 경우 저장이 안되는 이슈 해결 (#55)

### DIFF
--- a/ottogether/src/pages/Register/RegisterProfile.tsx
+++ b/ottogether/src/pages/Register/RegisterProfile.tsx
@@ -169,12 +169,14 @@ function RegisterProfile() {
   const handleHeaderImage = async () => {
     if(!userHeader) return getRandomHeader();
     
+    const extension = userHeader.name.split('.').pop()?.toLowerCase() || 'png';
+    const filtPath = `userHeader-${userId}.${extension}`;
     try {
       const result = await uploadImage( 
       { 
         bucketName: "headers",
         file: userHeader,
-        path: `userHeader-${userId}`
+        path: filtPath
       });
       if(result.success) {
         setFieldErrors(prev => ({...prev, header: undefined}));
@@ -195,13 +197,15 @@ function RegisterProfile() {
   /* 업로드한 파일이 있을 경우 Storage에 저장, 없으면 랜덤프로필 - Avatar */
   const handleAvatarImage = async () => {
     if(!userAvatar) return getRandomAvatar();
-      
+
+    const extension = userAvatar.name.split('.').pop()?.toLowerCase() || 'png';
+    const filtPath = `userAvatar-${userId}.${extension}`;
     try {
       const result = await uploadImage( 
       { 
         bucketName: "avatars",
         file: userAvatar,
-        path: `userAvatar-${userId}`
+        path: filtPath
       });
       if(result.success) {
         setFieldErrors(prev => ({...prev, avatar: undefined}));

--- a/ottogether/src/supabase/supabase.ts
+++ b/ottogether/src/supabase/supabase.ts
@@ -4,4 +4,10 @@ import type { Database } from './supabase.type';
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
 
-export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+    detectSessionInUrl: true,
+  }
+});


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
RegisterProfile 에서 값을 입력할 경우 저장이 안되는 이슈 해결
> Issue #55 

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
문제 원인 : 
- supabase upsert 시 기존에 들어있던 값을 삭제하고 새로 입력한 값만 들어가기 때문에, RegisterDetail에서 저장한 이메일 주소가 날아가서 email_address 의 not-null constraint 위반
- supabase storage에 파일 업로드 시 확장자를 포함한 상태로 auth.uid()와 비교하여 저장 권한이 없는 것으로 판단되어 RLS 위반

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
해결 방식 :
- 테이블 upsert 시 기존에 저장된 데이터를 가져와서 uploadData 와 merge 처리
- supabase storage RLS 수정

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
회원가입 시 프로필 사진이나 bio 같은 거 정상적으로 저장되는지 한 번 봐주세요!
