### PR TITLE
feat : EditPassword - 현재 비밀번호와 같은 비밀번호로 재설정 요청 시 에러 메시지 설정 (#32)

### DIFF
--- a/ottogether/src/pages/EditPassword/EditPassword.module.css
+++ b/ottogether/src/pages/EditPassword/EditPassword.module.css
@@ -108,16 +108,20 @@ input::placeholder {
   background-color: #a094ff;
 }
 
-.error {
-  color: var(--color-error-500);
+.message {
+  min-height: 1.2rem;
   font-size: 0.9rem;
   margin-top: 0.5rem;
+  text-align: center;
+  width: 100%;
 }
 
-.success {
+.message.error {
+  color: var(--color-error-500);
+}
+
+.message.success {
   color: var(--color-success-500);
-  font-size: 0.9rem;
-  margin-top: 0.5rem;
 }
 
 @media (max-width: 768px) {

--- a/ottogether/src/pages/EditPassword/EditPassword.tsx
+++ b/ottogether/src/pages/EditPassword/EditPassword.tsx
@@ -33,7 +33,9 @@ function EditPassword() {
     if (error) {
       console.error("비밀번호 변경 실패:", error.message);
 
-      if (error.message.includes("JWT expired") || error.message.includes("expired")) {
+      if (error.message.includes("New password should be different")) {
+        setError("기존 비밀번호와 동일한 비밀번호는 사용할 수 없습니다.");
+      } else if (error.message.includes("JWT expired") || error.message.includes("expired")) {
         setError("비밀번호 재설정 링크가 만료되었습니다. 다시 비밀번호 찾기를 진행해주세요.");
       } else {
         setError("비밀번호 변경에 실패했습니다. 다시 시도해주세요.");
@@ -46,7 +48,6 @@ function EditPassword() {
     setPassword("");
     setConfirmPassword("");
 
-    // 2초 후 로그인 페이지로 이동
     setTimeout(() => navigate("/login"), 2000);
   };
 
@@ -98,8 +99,10 @@ function EditPassword() {
 
           <button type="submit" className={S["save-button"]}>Save</button>
 
-          {error && <p className={S["error"]}>{error}</p>}
-          {success && <p className={S["success"]}>{success}</p>}
+
+          <div className={`${S.message} ${error ? S.error : success ? S.success : ""}`}>
+            {error ? error : success ? success : <span>&nbsp;</span>}
+          </div>
         </form>
       </div>
     </div>


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
비밀번호 변경 시 현재 비밀번호와 새로운 비밀번호가 동일한 경우 오류 메시지 출력 (#32)

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
비밀번호 변경 시 기존 비밀번호와 같은 비밀번호로 재설정 요청을 하는 경우 변경이 제한됩니다.
이 때 오류 발생 원인을 사용자에게 알려주기 위해 "비밀번호 변경에 실패했습니다. 다시 시도해주세요." 대신 "기존 비밀번호와 동일한 비밀번호는 사용할 수 없습니다."이 출력되도록 합니다.

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
